### PR TITLE
Array always out of bounds bug

### DIFF
--- a/src/klib/array.hh
+++ b/src/klib/array.hh
@@ -47,7 +47,7 @@ namespace kstd
                 // TODO: throw an error message
             #endif
 
-            return data[n];
+            return data[i];
         }
         T& operator[](unsigned int i)
         {
@@ -56,7 +56,7 @@ namespace kstd
                 // TODO: throw an error message
             #endif
 
-            return data[n];
+            return data[i];
         }
 
         unsigned int size() const 


### PR DESCRIPTION
When using the array and indexing an item an out of bounds error was ocurring always. 

The indexer operator was always indexing the n-th element (n is the size of the array). That's now fixed.